### PR TITLE
Using multi_json so we always use the fastest JSON parser available

### DIFF
--- a/lib/redditkit/response/parse_json.rb
+++ b/lib/redditkit/response/parse_json.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require 'json'
+require 'multi_json'
 
 module RedditKit
 
@@ -13,8 +13,8 @@ module RedditKit
       #   an application/json header, we want to return the body itself if the
       #   JSON parsing fails, because the response is still likely useful.
       def parse(body)
-        JSON.parse(body, :symbolize_names => true) unless body.nil?
-      rescue JSON::ParserError
+        MultiJson.load(body, :symbolize_names => true) unless body.nil?
+      rescue MultiJson::LoadError
         body
       end
 

--- a/redditkit.gemspec
+++ b/redditkit.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday', "~> 0.8"
+  spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_development_dependency 'dotenv'
 end


### PR DESCRIPTION
You should always use [MultiJSON](https://rubygems.org/gems/multi_json) to select the fastest JSON coder available in gems.
