### PR TITLE
Fix Client.register doc and functionality

### DIFF
--- a/lib/redditkit/client/users.rb
+++ b/lib/redditkit/client/users.rb
@@ -100,7 +100,7 @@ module RedditKit
       # @option options [String] captcha The user's response to the CAPTCHA challenge.
       # @option options [Boolean] remember Whether to keep the user's session cookie beyond the current session.
       def register(username, password, options = {})
-        parameters = { :user => username, :passwd => password, :passwd2 => password, :captcha => options[:captcha], :iden => options[:captcha_identifier] }
+        parameters = { :user => username, :passwd => password, :passwd2 => password, :email => options[:email], :captcha => options[:captcha], :iden => options[:captcha_identifier] }
         post('api/register', parameters)
       end
 

--- a/lib/redditkit/client/users.rb
+++ b/lib/redditkit/client/users.rb
@@ -93,14 +93,16 @@ module RedditKit
 
       # Registers a new reddit account. 
       #
-      # @option options [String] username The username to register.
-      # @option options [String] password The password for the account.
-      # @option options [String] email The optional email address for the account.
-      # @option options [String] captcha_identifier The identifier for the CAPTCHA challenge solved by the user.
-      # @option options [String] captcha The user's response to the CAPTCHA challenge.
+      # @param username [String] The username to register.
+      # @param password [String] The password for the account.
+      # @param captcha_identifier [String] The identifier for the CAPTCHA challenge solved by the user.
+      # @param captcha [String] The user's response to the CAPTCHA challenge.
       # @option options [Boolean] remember Whether to keep the user's session cookie beyond the current session.
-      def register(username, password, options = {})
-        parameters = { :user => username, :passwd => password, :passwd2 => password, :email => options[:email], :captcha => options[:captcha], :iden => options[:captcha_identifier] }
+      # @param options [String] email The optional email address for the account.
+      def register(username, password, captcha_identifier, captcha, options = {})
+        parameters = { :user => username, :passwd => password, :passwd2 => password, 
+                       :iden => captcha_identifier, :captcha => captcha, 
+                       :email => options[:email], :rem => options[:remember] }
         post('api/register', parameters)
       end
 

--- a/lib/redditkit/version.rb
+++ b/lib/redditkit/version.rb
@@ -2,7 +2,7 @@ module RedditKit
 
   # A class for managing RedditKit's version number.
   class Version
-    MAJOR = 1
+    MAJOR = 2
     MINOR = 0
     PATCH = 0
 

--- a/spec/redditkit/client/users_spec.rb
+++ b/spec/redditkit/client/users_spec.rb
@@ -84,7 +84,7 @@ describe RedditKit::Client::Users, :vcr do
     end
 
     it "requests the correct resource" do
-      RedditKit.register 'username', 'password'
+      RedditKit.register 'username', 'password', 'fake_captcha_id', 'fake_captcha_answer'
       expect(a_post('api/register')).to have_been_made
     end
   end


### PR DESCRIPTION
Register api documentation was inaccurate and required captcha items were in the options hash. Email was also missing.

The version bump I'm not sure you actually want. Feel free to disregard it or ask me to redo the pull request without it.
