### PR TITLE
Fixed permalink method to remove extra slash

### DIFF
--- a/lib/redditkit/link.rb
+++ b/lib/redditkit/link.rb
@@ -137,7 +137,7 @@ module RedditKit
     end
 
     def permalink
-      @permalink ||= 'http://reddit.com/' << @attributes[:permalink]
+      @permalink ||= 'http://reddit.com' << @attributes[:permalink]
     end
 
     # Returns the short URL for a link.


### PR DESCRIPTION
The permalink already comes with a prefix slash, and thus it is not needed in the reddit domain name. (Fixes: "http://reddit.com//r/lisp/comments/2cs6qo/mocl_lisp_for_ios_android_and_os_x/" with http://reddit.com/r/lisp/comments/2cs6qo/mocl_lisp_for_ios_android_and_os_x/)
