### PR TITLE
Adding user agent name and version to client constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ RedditKit.rb is used through either the `RedditKit` module, or `RedditKit::Clien
 **Module usage:**
 ```ruby
 RedditKit.sign_in 'username', 'password'
+RedditKit.user_agent = 'MyRedditBot/1.2 (+http://www.reddit.com/user/username)'
 subreddits = RedditKit.subscribed_subreddits
 ```
 
 **Instance method usage:**
 ```ruby
-client = RedditKit::Client.new 'username', 'password'
+client = RedditKit::Client.new 'username', 'password','MyRedditBot','1.2'
 subreddits = client.subscribed_subreddits
 ```
 
@@ -102,7 +103,30 @@ end
 
 You can configure various aspects of RedditKit.rb's operation, including its default API endpoint and user agent, by setting attributes on `RedditKit::Client`.
 
-**You should set your user agent to the name and version of your app, along with your reddit username. That way, if you ever have a buggy version of your app abusing the API, the reddit admins will know who to contact.**
+**You should set your user agent to the name and version of your app, along with your reddit username. That way, if you ever have a buggy version of your app abusing the API, the reddit admins will know who to contact.
+```ruby
+#Option 1
+MY_BOT_VERSION = 1.7
+client = RedditKit::Client.new 'myRedditUserName','password','myBotName',MY_BOT_VERSION
+puts client.user_agent
+# yields "myRedditUserName/1.7 (+http://www.reddit.com/user/myRedditUserName)"
+
+#Option 2
+client = RedditKit::Client.new 'myRedditUserName','password'
+client.user_agent_name = 'myBotName'
+client.user_agent_version = MY_BOT_VERSION
+#This also works with the module usage pattern
+RedditKit.sign_in 'myRedditUserName','password'
+RedditKit.user_agent_name = 'myBotName'
+RedditKit.user_agent_version = MY_BOT_VERSION
+
+#Option 3
+client = RedditKit::Client.new 'myRedditUserName','password'
+client.user_agent='myCustomAgentString/0.4 (+http://example.com/contact/info.html)'
+#This also works with the module usage pattern
+RedditKit.sign_in 'myRedditUserName','password'
+RedditKit.user_agent='myCustomAgentString/0.4 (+http://example.com/contact/info.html)'
+```
 
 ## Contributing
 

--- a/lib/redditkit/client.rb
+++ b/lib/redditkit/client.rb
@@ -48,12 +48,17 @@ module RedditKit
 
     attr_accessor :api_endpoint
     attr_accessor :authentication_endpoint
-    attr_accessor :user_agent
     attr_accessor :middleware
+    attr_accessor :user_agent
+    attr_accessor :user_agent_name
+    attr_accessor :user_agent_version
 
-    def initialize(username = nil, password = nil)
+    def initialize(username = nil, password = nil, agent_name = nil, agent_version = nil)
       @username = username
       @password = password
+
+      @user_agent_name = agent_name
+      @user_agent_version = agent_version
 
       @cookie = nil
       @modhash = nil
@@ -65,12 +70,25 @@ module RedditKit
       @api_endpoint ||= 'http://www.reddit.com/'
     end
 
-    def authentication_endpoint
-      @authentication_endpoint ||= 'https://ssl.reddit.com/'
+    def user_agent_name
+      @user_agent_name||="RedditKit.rb"
+    end
+
+    def user_agent_version
+      @user_agent_version||=RedditKit::Version.to_s
     end
 
     def user_agent
-      @user_agent ||= "RedditKit.rb #{RedditKit::Version.to_s}"
+      return @user_agent if @user_agent
+      if username
+        "#{user_agent_name}/#{user_agent_version} (+" << URI.join(api_endpoint,'/user/',username).to_s << ")"
+      else
+        "#{user_agent_name}/#{user_agent_version}"
+      end
+    end
+
+    def authentication_endpoint
+      @authentication_endpoint ||= 'https://ssl.reddit.com/'
     end
 
     def middleware

--- a/spec/redditkit/client_spec.rb
+++ b/spec/redditkit/client_spec.rb
@@ -4,7 +4,7 @@ describe RedditKit::Client, :vcr do
 
   it "can retrieve default options" do
     expect(RedditKit.api_endpoint).to eq 'http://www.reddit.com/'
-    expect(RedditKit.user_agent).to eq "RedditKit.rb #{RedditKit::Version}"
+    expect(RedditKit.user_agent).to eq "RedditKit.rb/#{RedditKit::Version}"
   end
 
   it "can configure options" do
@@ -12,6 +12,26 @@ describe RedditKit::Client, :vcr do
     client.api_endpoint = "http://github.com/"
 
     expect(client.api_endpoint).to eq "http://github.com/"
+  end
+
+  it "can configure an agent string" do
+    client = RedditKit::Client.new nil,nil,"TestAgentBot","86"
+
+    expect(client.user_agent).to eq "TestAgentBot/86"
+
+
+    client.user_agent_name = "OtherTestAgentBot"
+    client.user_agent_version = 99
+    expect(client.user_agent).to eq "OtherTestAgentBot/99"
+
+    client.user_agent = "ThirdTestAgentBot/7.00 (+http://www.reddit.com/user/user/samsymons)"
+    expect(client.user_agent).to eq "ThirdTestAgentBot/7.00 (+http://www.reddit.com/user/user/samsymons)"
+
+    client.user_agent = nil
+    expect(client.user_agent).to eq "OtherTestAgentBot/99"
+
+    client = RedditKit::Client.new "samsymons",nil,"FourthTestAgentBot","86"
+    expect(client.user_agent).to eq "FourthTestAgentBot/86 (+http://www.reddit.com/user/samsymons)"
   end
 
   it "should have a modhash and cookie after signing in" do


### PR DESCRIPTION
User Agent string is now easy to generate correctly

Client ctor has new optional parameters for constructing the user agent string.

The user agent string can still be set manually.

Added tests relavent tests.

Updated README.md
