### PR TITLE
Adding multiple_links helper method

### DIFF
--- a/lib/redditkit/client/links.rb
+++ b/lib/redditkit/client/links.rb
@@ -52,6 +52,14 @@ module RedditKit
         links.first
       end
 
+      # Gets an array of links from an array of full names.
+      #       
+      # @param links_full_name [Array<String>] An array of full names of links.
+      # @return [RedditKit::PaginatedResponse]
+      def multiple_links(links_full_name = [])
+        objects_from_response(:get, 'api/info.json', { :id => links_full_name.join(",") })
+      end
+
       # Gets links with a specific domain.
       #
       # @param domain [String] The domain for which to get links.


### PR DESCRIPTION
Adding multiple_links method call to allow pulling more than one specific link to help with issues in rate limiting when needing to check on multiple things