### PR TITLE
Use HTTPS API endpoint

### DIFF
--- a/lib/redditkit/client.rb
+++ b/lib/redditkit/client.rb
@@ -62,7 +62,7 @@ module RedditKit
     end
 
     def api_endpoint
-      @api_endpoint ||= 'http://www.reddit.com/'
+      @api_endpoint ||= 'https://www.reddit.com/'
     end
 
     def authentication_endpoint


### PR DESCRIPTION
Fixes #46 

Reddit API returns a 301 redirect to an HTTPS-secured URL when requesting a non-secured HTTPS URL and RedditKit was breaking because it doesn't expect that when authenticating the user