### PR TITLE
Fix editusertext action

### DIFF
--- a/lib/redditkit/client/miscellaneous.rb
+++ b/lib/redditkit/client/miscellaneous.rb
@@ -7,10 +7,15 @@ module RedditKit
       # Edit the text or a self post or comment.
       #
       # @param object [String, RedditKit::Comment, RedditKit::Link] A link or comment's full name, a RedditKit::Link, or a RedditKit::Subreddit.
-      # @option options [String] text The new text for the link or comment.
+      # @option options [String] :text The text to update with
       def edit(object, options)
-        parameters = { :text => options[:text], :thing_id => extract_full_name(object) }
-        post('/api/editusertext', parameters)
+        raise ArgumentError, "second paramater must be a hash." unless options.is_a?(Hash)
+        parameters = {
+          :text => options.fetch(:text),
+          :thing_id => extract_full_name(object),
+          :api_type => "json",
+        }
+        post '/api/editusertext', parameters
       end
 
       # Deletes a link or comment.


### PR DESCRIPTION
I was experiencing strange behaviour of Client::Miscellaneous#edit
method, because it somehow rendered the page (as HTML) when I wanted
to edit a comment.

However the comment was edited, the problem was, that the response was a HTML
DOM, which then raised a rate limit error because somewhere in that
DOM there was "RATELIMIT" written and that matched in
Error#from_status_code_and_body.

So I added the api_type key and it worked fine.
Plus I added a little guard to verify that `options` is a hash.
When I first used the edit function I just passed the text as the
second parameter, which then gave me a silly error that string cannot be converted into Integer.